### PR TITLE
[FIX] GoogleTranslate errors

### DIFF
--- a/app/lib/rails_i18n_manager/google_translate.rb
+++ b/app/lib/rails_i18n_manager/google_translate.rb
@@ -1,5 +1,6 @@
 module RailsI18nManager
   module GoogleTranslate
+    require 'easy_translate'
 
     def self.translate(text, from:, to:)
       api_key = RailsI18nManager.config.google_translate_api_key
@@ -13,7 +14,7 @@ module RailsI18nManager
         return nil
       end
 
-      EasyTranslate.translate(text, from: from, to: to, key: api_key)
+      translation = EasyTranslate.translate(text, from: from, to: to, key: api_key)
 
       if translation
         str = translation.to_s


### PR DESCRIPTION
# Description

This PR addresses an issue with the Google Translate functionality in `RailsI18nManager::GoogleTranslate` module. The following fixes have been implemented:

1. **Dependency Inclusion**: Added the missing `require 'easy_translate'` statement to ensure proper dependency utilization.
2. **Translation Method Refactor**: Modified the translation method to properly store the translation result in a variable, fixing the previous error.

This fix ensures that the Google Translate functionality now operates as intended, allowing for accurate translations and resolving any previous errors.