### PR TITLE
[FIX] Fixed cleaning old files in the export_to method

### DIFF
--- a/app/models/rails_i18n_manager/translation_key.rb
+++ b/app/models/rails_i18n_manager/translation_key.rb
@@ -80,9 +80,8 @@ module RailsI18nManager
       base_export_path = Rails.root.join("tmp/export/translations/")
 
       files_to_delete = Dir.glob("#{base_export_path}/*").each do |f|
-        if File.ctime(f) > 1.minutes.ago
+        if File.ctime(f) < 1.minutes.ago
           `rm -rf #{f}`
-          #File.delete(f)
         end
       end
 


### PR DESCRIPTION
# Description

Modified the condition for file deletion to ensure files older than 1 minute are removed.
