### PR TITLE
Ensure rspec rake task returns the exit code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,4 +58,6 @@ jobs:
 
     - name: Run tests
       run: |
-        bundle exec rake
+        bundle exec rake db:create
+        bundle exec rake db:migrate
+        bundle exec rake test

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ require 'bundler/gem_tasks'
 
 task :test do
   system("rspec", out: STDOUT)
+  exit $?.exitstatus
 end
 
 task default: :test


### PR DESCRIPTION
The default rake task (rake test) was not returning the exit code. This PR resolves this.