### PR TITLE
Make translations fully visible in view mode

### DIFF
--- a/app/helpers/rails_i18n_manager/custom_form_builder.rb
+++ b/app/helpers/rails_i18n_manager/custom_form_builder.rb
@@ -79,7 +79,7 @@ module RailsI18nManager
       options[:input_html][:class] ||= ""
       options[:input_html][:class].concat(" form-control-plaintext").strip!
       options[:input_html][:readonly] = true
-      options[:input_html][:type] = "textarea"
+      options[:input_html][:type] = "text"
       options[:input_html].delete(:name)
 
       if !options[:input_html].has_key?(:value)

--- a/app/helpers/rails_i18n_manager/custom_form_builder.rb
+++ b/app/helpers/rails_i18n_manager/custom_form_builder.rb
@@ -79,7 +79,7 @@ module RailsI18nManager
       options[:input_html][:class] ||= ""
       options[:input_html][:class].concat(" form-control-plaintext").strip!
       options[:input_html][:readonly] = true
-      options[:input_html][:type] = "text"
+      options[:input_html][:type] = "textarea"
       options[:input_html].delete(:name)
 
       if !options[:input_html].has_key?(:value)

--- a/app/views/rails_i18n_manager/form_builder/_basic_field.html.erb
+++ b/app/views/rails_i18n_manager/form_builder/_basic_field.html.erb
@@ -49,7 +49,7 @@
 
 <% field = capture do %>
   <% if type == :view %>
-    <%= text_field_tag nil, options[:input_html][:value], options[:input_html] %>
+    <%= text_area_tag nil, options[:input_html][:value], options[:input_html] %>
   <% elsif type == :select %>
     <%=
       f.select(


### PR DESCRIPTION
Currently, longer translations are not visible on the screen, and you need to scroll to see hidden parts of the translation. By making the read-only inputs text areas instead of text inputs, we can see the whole translation before editing it.

How it's looking currently:

<img width="894" alt="Screenshot 2024-09-04 at 11 49 19" src="https://github.com/user-attachments/assets/bfc604ea-989a-4825-9458-43ce14077f53">

After change:

<img width="913" alt="Screenshot 2024-09-04 at 12 06 20" src="https://github.com/user-attachments/assets/2ac94d30-15a6-4cc7-a8fa-02deecd251e4">

