### PR TITLE
Fix width issue on translation values form and view page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased - [View Diff](https://github.com/westonganger/rails_i18n_manager/compare/v1.0.1...master)
 - Drop support for Rails v5.x
+- [#19](https://github.com/westonganger/rails_i18n_manager/pull/19) - Fix width issue on translation values form and view page
 
 ### v1.0.1 - [View Diff](https://github.com/westonganger/rails_i18n_manager/compare/v1.0.0...v1.0.1)
 - [#14](https://github.com/westonganger/rails_i18n_manager/pull/14) - Remove usage of Array#intersection to fix errors in Ruby 2.6 and below

--- a/app/views/rails_i18n_manager/form_builder/_basic_field.html.erb
+++ b/app/views/rails_i18n_manager/form_builder/_basic_field.html.erb
@@ -7,7 +7,7 @@
     options[:label_wrapper_html][:class].concat(" col-md-1 col-form-label text-md-end").strip!
 
     options[:input_wrapper_html][:class] ||= ""
-    options[:input_wrapper_html][:class].concat(" col-auto g-md-0").strip!
+    options[:input_wrapper_html][:class].concat(" col-md-11").strip!
   end
 
   if type == :text_area
@@ -49,7 +49,7 @@
 
 <% field = capture do %>
   <% if type == :view %>
-    <%= text_field_tag nil, options[:input_html][:value], options[:input_html] %>
+    <%= text_area_tag nil, options[:input_html][:value], options[:input_html] %>
   <% elsif type == :select %>
     <%=
       f.select(

--- a/app/views/rails_i18n_manager/translations/_translation_value_fields.html.slim
+++ b/app/views/rails_i18n_manager/translations/_translation_value_fields.html.slim
@@ -7,4 +7,4 @@
 
 .nested-fields.translation-value-fields
   = f.hidden_field :locale
-  = f.field :translation, type: :textarea, label: "#{locale}", required: required, help_text: help_text, field_layout: :horizontal, input_html: {rows: 1, width: "100%;"}
+  = f.field :translation, type: :textarea, label: "#{locale}", required: required, help_text: help_text, field_layout: :horizontal, input_html: {rows: 1}


### PR DESCRIPTION
Solves #18 

# AFTER

<img width="1109" alt="Screenshot 2024-09-05 at 10 29 24 PM" src="https://github.com/user-attachments/assets/2076a86a-94cc-4d8e-9451-1372f0813dbc">

<img width="1118" alt="Screenshot 2024-09-05 at 10 29 31 PM" src="https://github.com/user-attachments/assets/eaaaa3bc-0828-4925-9d70-00bc72f8d319">

# BEFORE

<img width="755" alt="Screenshot 2024-09-05 at 10 31 49 PM" src="https://github.com/user-attachments/assets/561d38b6-153e-496d-b659-d2187955e16b">

<img width="697" alt="Screenshot 2024-09-05 at 10 31 43 PM" src="https://github.com/user-attachments/assets/f99900c6-9897-45af-976a-6bbea6a5c037">