### PR TITLE
Remove catch-all 404 route definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ### Unreleased - [View Diff](https://github.com/westonganger/rails_i18n_manager/compare/v1.1.0...master)
-- Nothing yet
+- [#25](https://github.com/westonganger/rails_i18n_manager/pull/25) - Remove catch-all 404 route definition
 
 ### v1.1.0 - January 17, 2025 - [View Diff](https://github.com/westonganger/rails_i18n_manager/compare/v1.0.3...v1.1.0)
 - [#24](https://github.com/westonganger/rails_i18n_manager/pull/24) - Completely remove usage of sprockets or propshaft

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,6 @@ RailsI18nManager::Engine.routes.draw do
 
   get "/robots", to: "application#robots", constraints: ->(req){ req.format == :text }
 
-  match "*a", to: "application#render_404", via: :get
-
   get "/", to: "translations#index"
 
   root "translations#index"


### PR DESCRIPTION
- The action for this route was not implemented
- A gem doesnt need a fancy catch-all 404 route, this is an application specific concern