### PR TITLE
Use permitted_classes: [Symbol] with YAML.safe_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ### Unreleased - [View Diff](https://github.com/westonganger/rails_i18n_manager/compare/v1.1.2...master)
-- Nothing yet
+- [#29](https://github.com/westonganger/rails_i18n_manager/pull/29) - Add `permitted_classes: [Symbol]` to `YAML.safe_load` call so that it will not error if there are values that start with a colon character (:)
 
 ### v1.1.2 - February 4, 2025 - [View Diff](https://github.com/westonganger/rails_i18n_manager/compare/v1.1.1...v1.1.2)
 - [#28](https://github.com/westonganger/rails_i18n_manager/pull/28) - Dont use dig method in import which could result in exception `TypeError: Undefined method dig for String`

--- a/app/lib/rails_i18n_manager/forms/translation_file_form.rb
+++ b/app/lib/rails_i18n_manager/forms/translation_file_form.rb
@@ -32,7 +32,7 @@ module RailsI18nManager
 
         case file_extname
         when ".yml", ".yaml"
-          @parsed_file_contents = YAML.safe_load(file_contents_string)
+          @parsed_file_contents = YAML.safe_load(file_contents_string, permitted_classes: [Symbol])
         when ".json"
           @parsed_file_contents = JSON.parse(file_contents_string)
         end


### PR DESCRIPTION
Add `permitted_classes: [Symbol]` to the `YAML.safe_load` call so that it will not error if there are values that start with a colon character (:)
