### PR TITLE
Fix for Rails 6.x where the multipart form enctype was not being applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ### Unreleased - [View Diff](https://github.com/westonganger/rails_i18n_manager/compare/v1.1.2...master)
+- [#30](https://github.com/westonganger/rails_i18n_manager/pull/30) - Fix for Rails 6.x where the multipart form enctype was not being applied
 - [#29](https://github.com/westonganger/rails_i18n_manager/pull/29) - Add `permitted_classes: [Symbol]` to `YAML.safe_load` call so that it will not error if there are values that start with a colon character (:)
 
 ### v1.1.2 - February 4, 2025 - [View Diff](https://github.com/westonganger/rails_i18n_manager/compare/v1.1.1...v1.1.2)

--- a/app/views/rails_i18n_manager/form_builder/_basic_field.html.erb
+++ b/app/views/rails_i18n_manager/form_builder/_basic_field.html.erb
@@ -71,6 +71,8 @@
     <% end %>
   <% elsif type == :textarea %>
     <%= f.text_area method, options[:input_html] %>
+  <% elsif type == :file %>
+    <%= f.file_field method, options[:input_html] %>
   <% else %>
     <%= f.text_field method, options[:input_html] %>
   <% end %>

--- a/app/views/rails_i18n_manager/translations/import.html.slim
+++ b/app/views/rails_i18n_manager/translations/import.html.slim
@@ -4,7 +4,7 @@ h2.page-sub-title Import Translations from Source File
 
 .row
   .col-6
-    = custom_form_for @form, as: :import_form, url: import_translations_path, method: :post, multipart: true, html: {class: "form-horizontal"} do |f|
+    = custom_form_for @form, as: :import_form, url: import_translations_path, method: :post, html: {multipart: true, class: "form-horizontal"} do |f|
       = f.error_notification
 
       = f.field :translation_app_id, label: "App Name", type: :select, collection: RailsI18nManager::TranslationApp.order(name: :asc).pluck(:name, :id)


### PR DESCRIPTION
Solves #20 

In Rails 6.x, `form_for ..., multipart: true` was not correctly applying the `enctype="multipart/form-data"` to the HTML `form` tag

Turns out that in Rails 6.x and prior you are supposed to either use:
- `form_for ..., html: {multipart: true}`
- OR
- If the form uses the `file_field` method then the enctype is automatically added

Both of the potential fixes for Rails 6.x, also work in Rails 7.0 and above