### PR TITLE
Fix missing float utility CSS classes

### DIFF
--- a/app/views/layouts/rails_i18n_manager/_utility_css.html.erb
+++ b/app/views/layouts/rails_i18n_manager/_utility_css.html.erb
@@ -1,4 +1,10 @@
 <style>
+  .pull-left{
+    float: left !important;
+  }
+  .pull-right{
+    float: right !important;
+  }
   .space-left{
     margin-left:5px !important;
   }


### PR DESCRIPTION
Somehow these CSS classes for `pull-right` and `pull-left` got removed and wasnt noticed (I think some outdated asset caching was in the mix here) but fixing it now